### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,4 +750,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/SwiftUI-Data-Visualization](https://starchart.cc/muhittincamdali/SwiftUI-Data-Visualization.svg)](https://github.com/muhittincamdali/SwiftUI-Data-Visualization/stargazers) 


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.