### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,25 @@
+# Documentation Index
+
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/AnimationGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/Charts.md
+- [](&)Documentation/BarChartAPI.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ChartAPI.md
+- [](&)Documentation/ChartTypesGuide.md
+- [](&)Documentation/CustomizationAPI.md
+- [](&)Documentation/CustomizationGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LineChartAPI.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/PieChartAPI.md
+- [](&)Documentation/ResponsiveDesignGuide.md
+- [](&)Documentation/ScatterPlotAPI.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,13 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedChartsExample.swift
+- ``Examples/AnalyticsExample/AnalyticsDashboard.swift
+- ``Examples/AnimationExamples/AnimationExamples.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicChartsExample.swift
+- ``Examples/BasicExamples/BasicLineChartExample.swift
+- ``Examples/CustomizationExamples/CustomizationExamples.swift
+- ``Examples/InteractiveExamples/InteractiveChartsExample.swift
+- ``Examples/InteractiveExamples/InteractiveExamples.swift
+- ``Examples/PerformanceExamples/PerformanceExamples.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.